### PR TITLE
Replaces hard-coded solr-field value with user-specified value.

### DIFF
--- a/islandora_url_redirector.module
+++ b/islandora_url_redirector.module
@@ -126,7 +126,8 @@ function islandora_url_redirector_id() {
 function islandora_url_redirector_query_solr($input) {
   $solr_url = variable_get('islandora_url_redirector_solr_base','http://localhost:8080/solr');
   
-  $field = "dc.identifier";
+  $field = variable_get("islandora_url_redirector_solr_field", "dc.identifier");
+  $field = empty($field) ? "dc.identifier" : $field;
   $query = $solr_url . '/select?version=1.2&wt=json&json.nl=map&q=' .
   $field . ':%22' . $input . '%22';
   $raw_result = drupal_http_request($query);


### PR DESCRIPTION
I could be mistaken, but it seemed to me that the admin for setting for 'solr field' was not being used by the logic. 

This change looks for a user-defined value in the variables table via `variable_get`, using `dc.identifier` as the default. Also reverts to the default when the user-supplied value is the empty string.